### PR TITLE
Fix ``YARR_LAYOUT_FIXED = False`` in JS

### DIFF
--- a/yarr/static/yarr/js/list_entries.js
+++ b/yarr/static/yarr/js/list_entries.js
@@ -58,7 +58,7 @@ $(function () {
         pageLength = $con.data('api-page-length'),
         
         // Whether or not the control bar and feed list should be fixed
-        layoutFixed = $con.data('layout-fixed', true)
+        layoutFixed = !!$con.data('layout-fixed')
     ;
     
     // Split pkAvailable


### PR DESCRIPTION
Was setting the data attribute instead of reading it.
