### PR TITLE
Using render() instead of render_to_response()

### DIFF
--- a/yarr/views.py
+++ b/yarr/views.py
@@ -4,8 +4,8 @@ from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
 from django.db import models as django_models
 from django.http import HttpResponseRedirect, Http404, HttpResponse
-from django.shortcuts import get_object_or_404, render_to_response
-from django.template import RequestContext, loader, Context
+from django.shortcuts import get_object_or_404, render
+from django.template import loader, Context
 from django.utils.html import escape
 
 from yarr import settings, utils, models, forms
@@ -99,7 +99,7 @@ def list_entries(
     elif not unread:
         current_view = 'yarr-list_all'
     
-    return render_to_response(template, RequestContext(request, {
+    return render(request, template, {
         'title':    title,
         'entries':  entries,
         'available_pks': available_pks,
@@ -115,7 +115,7 @@ def list_entries(
             'add_jquery':       settings.ADD_JQUERY,
             'api_page_length':  settings.API_PAGE_LENGTH,
         },
-    }))
+    })
     
     
 @login_required
@@ -174,11 +174,11 @@ def mark_read(
         title = 'Mark all as %s'
         msg = 'Are you sure you want to mark all items in every feed as %s?'
     
-    return render_to_response(template, RequestContext(request, {
+    return render(request, template, {
         'title':    title % display_op,
         'message':  msg % display_op,
         'submit_label': title % display_op,
-    }))
+    })
     
     
 @login_required
@@ -217,12 +217,12 @@ def mark_saved(
         title = 'Unsave item'
         msg = 'Are you sure you no longer want to save this item?'
     
-    return render_to_response(template, RequestContext(request, {
+    return render(request, template, {
         'title':    title,
         'message':  msg,
         'entry':    entry,
         'submit_label': title,
-    }))
+    })
     
 
 @login_required
@@ -239,7 +239,7 @@ def feeds(request, template="yarr/feeds.html"):
     
     add_form = forms.AddFeedForm()
     
-    return render_to_response(template, RequestContext(request, {
+    return render(request, template, {
         'title':    'Manage feeds',
         'feed_form': add_form,
         'feeds':    feeds,
@@ -247,7 +247,7 @@ def feeds(request, template="yarr/feeds.html"):
             'add_jquery':       settings.ADD_JQUERY,
             'api_base':         reverse('yarr-api_base'),
         },
-    }))
+    })
     
 
 @login_required
@@ -305,11 +305,11 @@ def feed_form(
     else:
         feed_form = form_class(instance=feed)
     
-    return render_to_response(template, RequestContext(request, {
+    return render(request, template, {
         'title':    title,
         'feed_form': feed_form,
         'feed':     feed,
-    }))
+    })
     
     
 @login_required
@@ -328,11 +328,11 @@ def feed_delete(request, feed_pk, template="yarr/confirm.html"):
         messages.success(request, 'Feed deleted')
         return HttpResponseRedirect(reverse(home))
     
-    return render_to_response(template, RequestContext(request, {
+    return render(request, template, {
         'title':    'Delete feed',
         'message':  'Are you sure you want to delete the feed "%s"?' % feed.title,
         'submit_label': 'Delete feed',
-    }))
+    })
 
 
 @login_required


### PR DESCRIPTION
It's shorter and the context_instance is set automatically. Before context_instance was not set at all.

I found out because the context was not showing up in the Django Debug Toolbar and there was an [issue suggesting this](https://github.com/django-debug-toolbar/django-debug-toolbar/issues/236#issuecomment-6572963).
