### PR TITLE
Don't change scroll position on entry click

### DIFF
--- a/yarr/static/yarr/js/list_entries.js
+++ b/yarr/static/yarr/js/list_entries.js
@@ -623,7 +623,6 @@ $(function () {
     $content
         .on('click', '.yarr_entry_content', function (e) {
             selectEntry($(this).parent().index());
-            scrollCurrent();
         })
         .on('click', '.yarr_entry_li', function (e) {
             var $entry = $(this).parent();
@@ -631,6 +630,9 @@ $(function () {
                 $entry.removeClass('yarr_open');
             } else {
                 selectEntry($entry.index());
+                // Since everything has shifted around we need to scroll to
+                // a known position or the user will be lost.
+                scrollCurrent();
             }
         })
     ;


### PR DESCRIPTION
It's annoying (especially on a tablet) when clicking an external link causes your scroll position to shoot up to the top of the entry, hiding the read/unread checkboxes.  This moves the scrolling to only occur in list mode, when selecting an item.
