### PR TITLE
Longer entry snippets in list mode

### DIFF
--- a/yarr/templates/yarr/include/entry.html
+++ b/yarr/templates/yarr/include/entry.html
@@ -10,7 +10,7 @@
         <div class="yarr_li_date">{{ entry.date|date:"M d Y, H:i" }}</div>
         <div class="yarr_li_entry">
             <span>{{ entry.title|default:"Untitled" }}</span>
-            - {{ entry.content|striptags|truncatechars:20|default:"..." }}
+            — {{ entry.content|truncatewords_html:30|striptags|default:"…" }}
         </div>
     </div>
     <div class="yarr_entry_content">


### PR DESCRIPTION
20 character isn't even enough to fill the screen on my phone, so make the snippet a bit longer.  Use `truncatewords_html` because plain `truncatewords` was giving strange results.  Move the tag stripping to after the truncation, hoping this reduces the processing required (but I didn't benchmark this).
