### PR TITLE
Add wrapper <span> for checkbox style-ability

### DIFF
--- a/yarr/static/yarr/js/list_entries.js
+++ b/yarr/static/yarr/js/list_entries.js
@@ -273,12 +273,13 @@ $(function () {
         ;
     }
     
-    function wrapCheckbox($box, label) {
+    function wrapCheckbox($box, cls, label) {
         /** Wrap a checkbox in a label */
-        return $('<label>' + label + '</label>')
+        return $('<label><span>' + label + '</span></label>')
             .prepend($box)
             .wrap('<li />')
             .parent()
+            .addClass(cls)
         ;
     }
     
@@ -330,8 +331,8 @@ $(function () {
         // Add buttons
         $entry.find('.yarr_entry_control')
             .empty()
-            .append(wrapCheckbox($read, 'Read'))
-            .append(wrapCheckbox($saved, 'Saved'))
+            .append(wrapCheckbox($read, 'yarr_checkbox_read', 'Read'))
+            .append(wrapCheckbox($saved, 'yarr_checkbox_saved', 'Saved'))
         ;
         
         // When images load, update the position cache


### PR DESCRIPTION
Because a checkbox is a replaced element it's not possible (in all browsers) to use `::before`/`::after` to generate content based on the `:checked` pseudo-class (which is useful if you want to replace the checkbox image).  The simplest workaround is to have an element following the checkbox which can be targeted with the `+` selector.
