### PR TITLE
1.6 compatibility - defaults has been removed.

### DIFF
--- a/yarr/urls.py
+++ b/yarr/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls.defaults import patterns, url
+except ImportError:
+    from django.conf.urls import patterns, url, include
 
 urlpatterns = patterns('yarr.views',
     url(r'^$', 'home',


### PR DESCRIPTION
django.conf.urls.defaults has been removed in Django 1.6 as per http://stackoverflow.com/questions/19962736/django-import-error-no-module-named-django-conf-urls-defaults
