### PR TITLE
Remove yarr_feed_unread class when zero unread

### DIFF
--- a/yarr/static/yarr/css/styles.css
+++ b/yarr/static/yarr/css/styles.css
@@ -262,6 +262,12 @@ ul.yarr_entry_control li label input {
     font-weight:    normal;
     color:          #666;
 }
+.yarr_count_unread::before {
+    content: "(";
+}
+.yarr_count_unread::after {
+    content: ")";
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 **                                                              List display

--- a/yarr/static/yarr/js/list_entries.js
+++ b/yarr/static/yarr/js/list_entries.js
@@ -328,8 +328,12 @@ $(function () {
                     // Update unread count in the feed list.
                     var counts = result['feed_unread'];
                     for (var pk in counts) {
-                        var selector = '[data-yarr-feed=' + pk + '] .yarr_count_unread';
-                        $feedList.find(selector).text('(' + counts[pk] + ')');
+                        var count = counts[pk];
+                        $feedList.find('[data-yarr-feed=' + pk + ']').each(function() {
+                            $(this)
+                                .toggleClass('yarr_feed_unread', count !== 0)
+                                .find('.yarr_count_unread').text(count);
+                        });
                     }
                 });
             })

--- a/yarr/templates/yarr/list_entries.html
+++ b/yarr/templates/yarr/list_entries.html
@@ -90,7 +90,7 @@
             <li data-yarr-feed="{{ feed.pk }}" {% if feed.count_unread %}class="yarr_feed_unread"{% endif %}>
                 <a href="{% url current_view feed_pk=feed.pk %}">
                     {{ feed.title }}
-                        <span class="yarr_count_unread">({{ feed.count_unread }})</span>
+                        <span class="yarr_count_unread">{{ feed.count_unread }}</span>
                 </a>
             </li>
             {% endfor %}


### PR DESCRIPTION
Also switch the default styling to use CSS to add parenthesis around the count, as they are difficult to remove otherwise (being present in both the HTML templates and the JS).
