### PR TITLE
Add top-level wrappers to the management pages

### DIFF
--- a/yarr/templates/yarr/base_manage.html
+++ b/yarr/templates/yarr/base_manage.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-<div class="yarr_control">
+<div class="yarr_control yarr_control_manage">
     <ul>
         <li><a href="{% url "yarr-home" %}">Browse items</a></li>
         {% if not feeds %}

--- a/yarr/templates/yarr/feed_add.html
+++ b/yarr/templates/yarr/feed_add.html
@@ -4,8 +4,10 @@
 
 {% block content %}
 
-{{ block.super }}
+<div id="yarr_feed_add">
+    {{ block.super }}
 
-{% include "yarr/include/form_feed_add.html" %}
+    {% include "yarr/include/form_feed_add.html" %}
+</div>
 
 {% endblock %}

--- a/yarr/templates/yarr/feed_edit.html
+++ b/yarr/templates/yarr/feed_edit.html
@@ -4,8 +4,10 @@
 
 {% block content %}
 
-{{ block.super }}
+<div id="yarr_feed_edit">
+    {{ block.super }}
 
-{% include "yarr/include/form_feed_edit.html" %}
+    {% include "yarr/include/form_feed_edit.html" %}
+</div>
 
 {% endblock %}

--- a/yarr/templates/yarr/feeds.html
+++ b/yarr/templates/yarr/feeds.html
@@ -8,6 +8,8 @@
 {% endblock %}
 
 {% block content %}
+<div id="yarr_feeds">
+
 {{ block.super }}
 
 <h2>Add feed</h2>
@@ -65,5 +67,7 @@
     {% endfor %}
     </tbody>
 </table>
+
+</div>
 
 {% endblock %}


### PR DESCRIPTION
Containers analogous to `#yarr_con` on the list_entries page, named for the associated templates.

These are useful as styling hooks.  In my styles, I use them to apply padding to the container which is not present on `#yarr_con`.

I didn't indent the content of feeds.html because it would explode the diff, but I'd be happy to amend the PR to do so if you like.
